### PR TITLE
Added support for installation on arm platforms

### DIFF
--- a/golang/init.sls
+++ b/golang/init.sls
@@ -10,7 +10,7 @@ golang|cache-archive:
   file.managed:
     - name: /tmp/{{ config.archive_name }}
     - source: https://storage.googleapis.com/golang/{{ config.archive_name }}
-    - source_hash: sha256={{ config.archive_hash }}
+    - source_hash: https://storage.googleapis.com/golang/{{ config.archive_name }}.sha256
     - user: root
     - group: root
     - unless:
@@ -29,8 +29,8 @@ golang|extract-archive:
         - {{ config.go_path }}
     - user: root
     - group: root
-    - mode: 775
-    - makedirs: truen
+    - mode: 755
+    - makedirs: True
     - unless:
         - test -d {{ config.base_dir }}
     - recurse:
@@ -41,7 +41,7 @@ golang|extract-archive:
   archive.extracted:
     - name: {{ config.base_dir }}
     - source: "/tmp/{{ config.archive_name }}"
-    - source_hash: sha256={{ config.archive_hash }}
+    - source_hash: https://storage.googleapis.com/golang/{{ config.archive_name }}.sha256
     - archive_format: tar
     - user: root
     - group: root

--- a/golang/map.jinja
+++ b/golang/map.jinja
@@ -1,7 +1,27 @@
 {% from "golang/defaults.yaml" import lookup_map with context %}
 {% set config = salt['grains.filter_by'](lookup_map, merge=salt['pillar.get']('golang:lookup', salt['grains.get']('golang:lookup', {}), merge=True), base='default') %}
 
+{##
+Add any overrides based on CPU architecture.
+##}
+{% set cpu_arch_map = salt['grains.filter_by']({
+        'armv6l': {
+            "arch": 'armv6l'
+        },
+        'armv7l': {
+            "arch": 'armv6l'
+        },
+        'x86_64': {
+            "arch": 'amd64'
+        }
+  }
+  , grain="cpuarch"
+  , merge=salt['pillar.get']('golang:lookup'))
+%}
+{% do config.update(cpu_arch_map) %}
+
+
 {% do config.update({
-  'archive_name': 'go%s.linux-amd64.tar.gz'|format(config.version),
+  'archive_name': 'go%s.linux-%s.tar.gz'|format(config.version, config.arch),
   'base_dir': '%s/golang/%s'|format(config.prefix, config.version)
 }) %}


### PR DESCRIPTION
I tweaked the formula a little bit to allow fetching binary packages for platforms other than amd64. This makes it possible to use the formula on a Raspberry Pi running Debian.

I also fixed one typo in the `makedirs` statement in one of the states and changed the permissions on another which were a bit way too permissive (755 in place of 775). 

Other than these changes I added a version bump to the latest one available and some links to sha256 hashes coming straight from the website. 