### PR TITLE
Let alternatives.install be conditional on pillar data

### DIFF
--- a/golang/defaults.yaml
+++ b/golang/defaults.yaml
@@ -1,6 +1,10 @@
 golang:
   prefix: /usr/local
   go_root: /usr/local/go
-  go_path: /var/lib/golang
+  go_path: /usr/local/go/bin
   version: "1.10"
   archive_hash: "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33"
+
+  #'Alternatives system' priority: 0 disables. zero is default
+  linux:
+    altpriority: 0

--- a/golang/init.sls
+++ b/golang/init.sls
@@ -53,29 +53,33 @@ golang|extract-archive:
         - go version | grep {{ golang.version }}
         - test -x {{ golang.base_dir }}/go/bin/go
 
+  {%- if golang.linux.altpriority > 0 %}
+
 # add a symlink from versioned install to point at golang:lookup:go_root
 golang|update-alternatives:
   alternatives.install:
     - name: golang-home-link
     - link: {{ golang.go_root }}
     - path: {{ golang.base_dir }}/go/
-    - priority: 31
+    - priority: {{ golang.linux.altpriority }}
     - order: 10
     - watch:
         - archive: golang|extract-archive
 
 # add symlinks to /usr/bin for the three go commands
-{% for i in ['go', 'godoc', 'gofmt'] %}
+     {% for i in ['go', 'godoc', 'gofmt'] %}
 golang|create-symlink-{{ i }}:
   alternatives.install:
     - name: link-{{ i }}
     - link: /usr/bin/{{ i }}
     - path: {{ golang.go_root }}/bin/{{ i }}
-    - priority: 40
+    - priority: {{ golang.linux.altpriority }}
     - order: 10
     - watch:
         - archive: golang|extract-archive
-{% endfor %}
+     {% endfor %}
+
+  {%- endif %}
 
 # sets up the necessary environment variables required for golang usage
 golang|setup-bash-profile:

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,7 @@
 golang:
   lookup:
     version: 1.8.3
+
+  #'Alternatives system' priority (0 disables). zero is default.
+  linux:
+    #altpriority: {{ range(1, 9100000) | random }}


### PR DESCRIPTION
This PR makes linux alternatives optional - disabled by default and controlled by pillar data.

While running the formula I noticed following messages on reruns:
```
[ERROR   ] Alternative for link-godoc not installed: 
[ERROR   ] Alternative for link-gofmt not installed: 
[ERROR   ] Alternative for link-go not installed:
```
When alternatives.install.priority is hardcoded the state can fail on reruns anyway.  Moving this parameter to pillar data is best way to facilitate clean reruns of state.   The `go_path` in `defaults.yaml` also pointed to non-existing directory - corrected.

Verified on Ubuntu.
```
 Comment: Alternatives for golang-home-link is already set to /usr/local/golang/1.10/go/
 Comment: Alternatives for link-godoc is already set to /usr/local/golang/bin/godoc
 Comment: Alternatives for link-gofmt is already set to /usr/local/golang/bin/gofmt
```
Helps resolve https://github.com/saltstack-formulas/opensds-formula/issues/1 too