### PR TITLE
Fix linux alternatives

### DIFF
--- a/golang/defaults.yaml
+++ b/golang/defaults.yaml
@@ -1,7 +1,7 @@
 golang:
   prefix: /usr/local
   go_root: /usr/local/go
-  go_path: /usr/local/go/bin
+  go_path: /usr/local/golang/packages
   version: "1.10"
   archive_hash: "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33"
 

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,8 @@
 golang:
   lookup:
     version: 1.8.3
+    go_path: ~/golang
 
   #'Alternatives system' priority (0 disables). zero is default.
   linux:
-    #altpriority: {{ range(1, 9100000) | random }}
+    altpriority: {{ range(1, 9100000) | random }}


### PR DESCRIPTION
This PR fixes linux alternatives - they were not working properly.  Verified on cent7.


```
          ID: golang|install-home-alternative
    Function: alternatives.install
        Name: golang-home-link
      Result: True
     Comment: Alternative for golang-home-link set to path /usr/local/golang/1.10/go/ with priority 4882970
     Started: 10:14:55.666385
    Duration: 8.059 ms
     Changes:   
              ----------
              link:
                  /usr/local/go
              name:
                  golang-home-link
              path:
                  /usr/local/golang/1.10/go/
              priority:
                  4882970
----------
          ID: golang|set-home-alternative
    Function: alternatives.set
        Name: golang-home-link
      Result: True
     Comment: Alternative for golang-home-link not updated
     Started: 10:14:55.681143
    Duration: 16.929 ms
     Changes:   
----------
          ID: golang|create-symlink-godoc
    Function: alternatives.install
        Name: link-godoc
      Result: True
     Comment: Alternative for link-godoc set to path /usr/local/go/bin/godoc with priority 4882970
     Started: 10:14:55.698747
    Duration: 8.081 ms
     Changes:   
              ----------
              link:
                  /usr/bin/godoc
              name:
                  link-godoc
              path:
                  /usr/local/go/bin/godoc
              priority:
                  4882970
----------
          ID: golang|create-symlink-gofmt
    Function: alternatives.install
        Name: link-gofmt
      Result: True
     Comment: Alternative for link-gofmt set to path /usr/local/go/bin/gofmt with priority 4882970
     Started: 10:14:55.714821
    Duration: 9.42 ms
     Changes:   
              ----------
              link:
                  /usr/bin/gofmt
              name:
                  link-gofmt
              path:
                  /usr/local/go/bin/gofmt
              priority:
                  4882970
----------
          ID: golang|create-symlink-go
    Function: alternatives.install
        Name: link-go
      Result: True
     Comment: Alternative for link-go set to path /usr/local/go/bin/go with priority 4882970
     Started: 10:14:55.732269
    Duration: 8.856 ms
     Changes:   
              ----------
              link:
                  /usr/bin/go
              name:
                  link-go
              path:
                  /usr/local/go/bin/go
              priority:
                  4882970
----------
          ID: golang|extract-archive
    Function: file.directory
        Name: /usr/local/golang/1.10
      Result: True
     Comment: unless condition is true
     Started: 10:14:55.741393
    Duration: 16.306 ms
     Changes:   
----------
          ID: golang|extract-archive
    Function: file.directory
        Name: /usr/local/go
      Result: True
     Comment: unless condition is true
     Started: 10:14:55.758052
    Duration: 15.383 ms
     Changes:   
----------
          ID: golang|set-symlink=go
    Function: alternatives.set
        Name: link-go
      Result: True
     Comment: Alternative for link-go already set to /usr/local/go/bin/go
     Started: 10:14:55.774190
    Duration: 0.576 ms
     Changes:   
----------
          ID: golang|set-symlink=godoc
    Function: alternatives.set
        Name: link-godoc
      Result: True
     Comment: Alternative for link-godoc already set to /usr/local/go/bin/godoc
     Started: 10:14:55.775226
    Duration: 0.372 ms
     Changes:   
----------
          ID: golang|set-symlink=gofmt
    Function: alternatives.set
        Name: link-gofmt
      Result: True
     Comment: Alternative for link-gofmt already set to /usr/local/go/bin/gofmt
     Started: 10:14:55.775964
    Duration: 0.429 ms
     Changes:   
----------
          ID: golang|setup-bash-profile
    Function: file.managed
        Name: /etc/profile.d/golang.sh
      Result: True
     Comment: File /etc/profile.d/golang.sh is in the correct state
     Started: 10:14:55.776546
    Duration: 49.903 ms
     Changes:   

Summary for local
-------------
Succeeded: 13 (changed=5)
Failed:     0
-------------
Total states run:     13
Total run time:    7.281 s



[vagrant@localhost alternatives]$ which go
/usr/bin/go
```