### PR TITLE
Always retry alternatives.install state

### DIFF
--- a/golang/init.sls
+++ b/golang/init.sls
@@ -63,47 +63,35 @@ golang|extract-archive:
 
 # add a symlink from versioned install to point at golang:lookup:go_root
 golang|install-home-alternative:
-      {%- if grains.os_family in ('Suse',) %}
-  cmd.run:
-    - name: update-alternatives --install {{ golang.go_root }} golang-home-link {{ golang.base_dir }}/go/ {{ golang.linux.altpriority }}
-      {%- else %}
   alternatives.install:
     - name: golang-home-link
     - link: {{ golang.go_root }}
     - path: {{ golang.base_dir }}/go/
     - priority: {{ golang.linux.altpriority }}
     - order: 10
-      {%- endif %}
     - watch:
         - archive: golang|extract-archive
     - retry:
         attempts: 2
         until: True
 
-      {%- if grains.os_family not in ('Suse',) %}
 golang|set-home-alternative:
   alternatives.set:
     - name: golang-home-link
     - path: {{ golang.base_dir }}/go/
     - require:
       - alternatives: golang|install-home-alternative
-     {%- endif %}
 
      {% for i in ['go', 'godoc', 'gofmt'] %}
 
      #manage symlinks to /usr/bin for the three go commands
 golang|create-symlink-{{ i }}:
-      {%- if grains.os_family in ('Suse',) %}
-  cmd.run:
-    - name: update-alternatives --install /usr/bin/{{ i }} link-{{ i }} {{ golang.base_dir }}/go/bin/{{ i }} {{ golang.linux.altpriority }}
-      {%- else %}
   alternatives.install:
     - name: link-{{ i }}
     - link: /usr/bin/{{ i }}
     - path: {{ golang.base_dir }}/go/bin/{{ i }}
     - priority: {{ golang.linux.altpriority }}
     - order: 10
-      {%- endif %}
     - watch:
       - archive: golang|extract-archive
     - require:
@@ -113,14 +101,12 @@ golang|create-symlink-{{ i }}:
         attempts: 2
         until: True
 
-      {%- if grains.os_family not in ('Suse',) %}
 golang|set-symlink={{ i }}:
   alternatives.set:
     - name: link-{{ i }}
     - path: {{ golang.base_dir }}/go/bin/{{ i }}
     - require:
       - alternatives: golang|create-symlink-{{ i }}
-      {%- endif %}
 
      {% endfor %}
   {%- endif %}

--- a/golang/init.sls
+++ b/golang/init.sls
@@ -63,47 +63,60 @@ golang|extract-archive:
 
 # add a symlink from versioned install to point at golang:lookup:go_root
 golang|install-home-alternative:
+      {%- if grains.os_family in ('Suse',) %}
+  cmd.run:
+    - name: update-alternatives --install {{ golang.go_root }} golang-home-link {{ golang.base_dir }}/go/ {{ golang.linux.altpriority }}
+      {%- else %}
   alternatives.install:
     - name: golang-home-link
     - link: {{ golang.go_root }}
     - path: {{ golang.base_dir }}/go/
     - priority: {{ golang.linux.altpriority }}
     - order: 10
+      {%- endif %}
     - watch:
         - archive: golang|extract-archive
 
+      {%- if grains.os_family not in ('Suse',) %}
 golang|set-home-alternative:
   alternatives.set:
     - name: golang-home-link
     - path: {{ golang.base_dir }}/go/
     - require:
       - alternatives: golang|install-home-alternative
+     {%- endif %}
 
      {% for i in ['go', 'godoc', 'gofmt'] %}
 
      #manage symlinks to /usr/bin for the three go commands
 golang|create-symlink-{{ i }}:
+      {%- if grains.os_family in ('Suse',) %}
+  cmd.run:
+    - name: update-alternatives --install /usr/bin/{{ i }} link-{{ i }} {{ golang.base_dir }}/go/bin/{{ i }} {{ golang.linux.altpriority }}
+      {%- else %}
   alternatives.install:
     - name: link-{{ i }}
     - link: /usr/bin/{{ i }}
     - path: {{ golang.base_dir }}/go/bin/{{ i }}
     - priority: {{ golang.linux.altpriority }}
     - order: 10
+      {%- endif %}
     - watch:
       - archive: golang|extract-archive
     - require:
       - alternatives: golang|install-home-alternative
       - alternatives: golang|set-home-alternative
 
+      {%- if grains.os_family not in ('Suse',) %}
 golang|set-symlink={{ i }}:
   alternatives.set:
     - name: link-{{ i }}
     - path: {{ golang.base_dir }}/go/bin/{{ i }}
     - require:
       - alternatives: golang|create-symlink-{{ i }}
+      {%- endif %}
 
      {% endfor %}
-
   {%- endif %}
 
 # sets up the necessary environment variables required for golang usage

--- a/golang/init.sls
+++ b/golang/init.sls
@@ -76,6 +76,9 @@ golang|install-home-alternative:
       {%- endif %}
     - watch:
         - archive: golang|extract-archive
+    - retry:
+        attempts: 2
+        until: True
 
       {%- if grains.os_family not in ('Suse',) %}
 golang|set-home-alternative:
@@ -106,6 +109,9 @@ golang|create-symlink-{{ i }}:
     - require:
       - alternatives: golang|install-home-alternative
       - alternatives: golang|set-home-alternative
+    - retry:
+        attempts: 2
+        until: True
 
       {%- if grains.os_family not in ('Suse',) %}
 golang|set-symlink={{ i }}:


### PR DESCRIPTION
This PR introduces retries because salt `alternatives.install` sometimes fails on 1st run.

**Verified on SuSE.**
```
          ID: golang|install-home-alternative
    Function: alternatives.install
        Name: golang-home-link
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for golang-home-link not installed: update-alternatives: using /usr/local/golang/1.10/go/ to provide /usr/local/go (golang-home-link) in auto mode"
              Alternatives for golang-home-link is already set to /usr/local/golang/1.10/go/
     Started: 01:22:42.944665
    Duration: 30009.314 ms
     Changes:   
----------
          ID: golang|set-home-alternative
    Function: alternatives.set
        Name: golang-home-link
      Result: True
     Comment: Alternative for golang-home-link already set to /usr/local/golang/1.10/go/
     Started: 01:23:12.990676
    Duration: 0.401 ms
     Changes:   
----------
          ID: golang|create-symlink-godoc
    Function: alternatives.install
        Name: link-godoc
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for link-godoc not installed: update-alternatives: using /usr/local/golang/1.10/go/bin/godoc to provide /usr/bin/godoc (link-godoc) in auto mode"
              Alternatives for link-godoc is already set to /usr/local/golang/1.10/go/bin/godoc
     Started: 01:23:12.991354
    Duration: 30012.586 ms
     Changes:   
----------
          ID: golang|create-symlink-gofmt
    Function: alternatives.install
        Name: link-gofmt
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for link-gofmt not installed: update-alternatives: using /usr/local/golang/1.10/go/bin/gofmt to provide /usr/bin/gofmt (link-gofmt) in auto mode"
              Alternatives for link-gofmt is already set to /usr/local/golang/1.10/go/bin/gofmt
     Started: 01:23:43.040218
    Duration: 30013.047 ms
     Changes:   
----------
          ID: golang|create-symlink-go
    Function: alternatives.install
        Name: link-go
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for link-go not installed: update-alternatives: using /usr/local/golang/1.10/go/bin/go to provide /usr/bin/go (link-go) in auto mode"
              Alternatives for link-go is already set to /usr/local/golang/1.10/go/bin/go
     Started: 01:24:13.088768
    Duration: 30011.796 ms
     Changes:   
----------
          ID: golang|set-symlink=go
    Function: alternatives.set
        Name: link-go
      Result: True
     Comment: Alternative for link-go already set to /usr/local/golang/1.10/go/bin/go
     Started: 01:24:43.153058
    Duration: 0.636 ms
     Changes:   
----------
          ID: golang|set-symlink=godoc
    Function: alternatives.set
        Name: link-godoc
      Result: True
     Comment: Alternative for link-godoc already set to /usr/local/golang/1.10/go/bin/godoc
     Started: 01:24:43.154076
    Duration: 0.347 ms
     Changes:   
----------
          ID: golang|set-symlink=gofmt
    Function: alternatives.set
        Name: link-gofmt
      Result: True
     Comment: Alternative for link-gofmt already set to /usr/local/golang/1.10/go/bin/gofmt
     Started: 01:24:43.154840
    Duration: 0.347 ms
     Changes: 

```