### PR TITLE
Always retry alternatives.install state

### DIFF
--- a/golang/init.sls
+++ b/golang/init.sls
@@ -63,47 +63,60 @@ golang|extract-archive:
 
 # add a symlink from versioned install to point at golang:lookup:go_root
 golang|install-home-alternative:
+      {%- if grains.os_family in ('Suse',) %}
+  cmd.run:
+    - name: update-alternatives --install {{ golang.go_root }} golang-home-link {{ golang.base_dir }}/go/ {{ golang.linux.altpriority }}
+      {%- else %}
   alternatives.install:
     - name: golang-home-link
     - link: {{ golang.go_root }}
     - path: {{ golang.base_dir }}/go/
     - priority: {{ golang.linux.altpriority }}
     - order: 10
+      {%- endif %}
     - watch:
         - archive: golang|extract-archive
 
+      {%- if grains.os_family not in ('Suse',) %}
 golang|set-home-alternative:
   alternatives.set:
     - name: golang-home-link
     - path: {{ golang.base_dir }}/go/
     - require:
       - alternatives: golang|install-home-alternative
+     {%- endif %}
 
      {% for i in ['go', 'godoc', 'gofmt'] %}
 
      #manage symlinks to /usr/bin for the three go commands
 golang|create-symlink-{{ i }}:
+      {%- if grains.os_family in ('Suse',) %}
+  cmd.run:
+    - name: update-alternatives --install /usr/bin/{{ i }} link-{{ i }} {{ golang.base_dir }}/go/bin/{{ i }} {{ golang.linux.altpriority }}
+      {%- else %}
   alternatives.install:
     - name: link-{{ i }}
     - link: /usr/bin/{{ i }}
     - path: {{ golang.base_dir }}/go/bin/{{ i }}
     - priority: {{ golang.linux.altpriority }}
     - order: 10
+      {%- endif %}
     - watch:
       - archive: golang|extract-archive
     - require:
       - alternatives: golang|install-home-alternative
       - alternatives: golang|set-home-alternative
 
+      {%- if grains.os_family not in ('Suse',) %}
 golang|set-symlink={{ i }}:
   alternatives.set:
     - name: link-{{ i }}
     - path: {{ golang.base_dir }}/go/bin/{{ i }}
     - require:
       - alternatives: golang|create-symlink-{{ i }}
+      {%- endif %}
 
      {% endfor %}
-
   {%- endif %}
 
 # sets up the necessary environment variables required for golang usage

--- a/golang/init.sls
+++ b/golang/init.sls
@@ -63,22 +63,19 @@ golang|extract-archive:
 
 # add a symlink from versioned install to point at golang:lookup:go_root
 golang|install-home-alternative:
-      {%- if grains.os_family in ('Suse',) %}
+           {%- if grains.os_family in ('Suse',) %}
   cmd.run:
     - name: update-alternatives --install {{ golang.go_root }} golang-home-link {{ golang.base_dir }}/go/ {{ golang.linux.altpriority }}
-      {%- else %}
+           {%- else %}
   alternatives.install:
     - name: golang-home-link
     - link: {{ golang.go_root }}
     - path: {{ golang.base_dir }}/go/
     - priority: {{ golang.linux.altpriority }}
     - order: 10
-      {%- endif %}
+           {%- endif %}
     - watch:
         - archive: golang|extract-archive
-    - retry:
-        attempts: 2
-        until: True
 
       {%- if grains.os_family not in ('Suse',) %}
 golang|set-home-alternative:
@@ -93,25 +90,23 @@ golang|set-home-alternative:
 
      #manage symlinks to /usr/bin for the three go commands
 golang|create-symlink-{{ i }}:
-      {%- if grains.os_family in ('Suse',) %}
+           {%- if grains.os_family in ('Suse',) %}
   cmd.run:
     - name: update-alternatives --install /usr/bin/{{ i }} link-{{ i }} {{ golang.base_dir }}/go/bin/{{ i }} {{ golang.linux.altpriority }}
-      {%- else %}
+    - require:
+      - cmd: golang|install-home-alternative
+         {%- else %}
   alternatives.install:
     - name: link-{{ i }}
     - link: /usr/bin/{{ i }}
     - path: {{ golang.base_dir }}/go/bin/{{ i }}
     - priority: {{ golang.linux.altpriority }}
     - order: 10
-      {%- endif %}
-    - watch:
-      - archive: golang|extract-archive
     - require:
       - alternatives: golang|install-home-alternative
-      - alternatives: golang|set-home-alternative
-    - retry:
-        attempts: 2
-        until: True
+         {%- endif %}
+    - watch:
+      - archive: golang|extract-archive
 
       {%- if grains.os_family not in ('Suse',) %}
 golang|set-symlink={{ i }}:

--- a/golang/init.sls
+++ b/golang/init.sls
@@ -93,7 +93,7 @@ golang|create-symlink-{{ i }}:
     - priority: {{ golang.linux.altpriority }}
     - order: 10
     - require:
-      - alternatives: golang|install-home-alternativ
+      - alternatives: golang|install-home-alternative
     - watch:
       - archive: golang|extract-archive
     - retry:

--- a/golang/init.sls
+++ b/golang/init.sls
@@ -63,61 +63,53 @@ golang|extract-archive:
 
 # add a symlink from versioned install to point at golang:lookup:go_root
 golang|install-home-alternative:
-           {%- if grains.os_family in ('Suse',) %}
-  cmd.run:
-    - name: update-alternatives --install {{ golang.go_root }} golang-home-link {{ golang.base_dir }}/go/ {{ golang.linux.altpriority }}
-           {%- else %}
   alternatives.install:
     - name: golang-home-link
     - link: {{ golang.go_root }}
     - path: {{ golang.base_dir }}/go/
     - priority: {{ golang.linux.altpriority }}
     - order: 10
-           {%- endif %}
     - watch:
         - archive: golang|extract-archive
+    - retry:
+        attempts: 2
+        until: True
 
-      {%- if grains.os_family not in ('Suse',) %}
 golang|set-home-alternative:
   alternatives.set:
     - name: golang-home-link
     - path: {{ golang.base_dir }}/go/
     - require:
       - alternatives: golang|install-home-alternative
-     {%- endif %}
 
      {% for i in ['go', 'godoc', 'gofmt'] %}
 
      #manage symlinks to /usr/bin for the three go commands
 golang|create-symlink-{{ i }}:
-           {%- if grains.os_family in ('Suse',) %}
-  cmd.run:
-    - name: update-alternatives --install /usr/bin/{{ i }} link-{{ i }} {{ golang.base_dir }}/go/bin/{{ i }} {{ golang.linux.altpriority }}
-    - require:
-      - cmd: golang|install-home-alternative
-         {%- else %}
   alternatives.install:
     - name: link-{{ i }}
     - link: /usr/bin/{{ i }}
     - path: {{ golang.base_dir }}/go/bin/{{ i }}
     - priority: {{ golang.linux.altpriority }}
     - order: 10
-    - require:
-      - alternatives: golang|install-home-alternative
-         {%- endif %}
     - watch:
       - archive: golang|extract-archive
+    - require:
+      - alternatives: golang|install-home-alternative
+      - alternatives: golang|set-home-alternative
+    - retry:
+        attempts: 2
+        until: True
 
-      {%- if grains.os_family not in ('Suse',) %}
 golang|set-symlink={{ i }}:
   alternatives.set:
     - name: link-{{ i }}
     - path: {{ golang.base_dir }}/go/bin/{{ i }}
     - require:
       - alternatives: golang|create-symlink-{{ i }}
-      {%- endif %}
 
      {% endfor %}
+
   {%- endif %}
 
 # sets up the necessary environment variables required for golang usage

--- a/golang/init.sls
+++ b/golang/init.sls
@@ -76,6 +76,9 @@ golang|install-home-alternative:
       {%- endif %}
     - watch:
         - archive: golang|extract-archive
+    - retry:
+        attempts: 2
+        until: True
 
       {%- if grains.os_family not in ('Suse',) %}
 golang|set-home-alternative:
@@ -106,6 +109,9 @@ golang|create-symlink-{{ i }}:
     - require:
       - alternatives: golang|install-home-alternative
       - alternatives: golang|set-home-alternative
+    - retry:
+        attempts: 2
+        until: True
 
       {%- if grains.os_family not in ('Suse',) %}
 golang|set-symlink={{ i }}:


### PR DESCRIPTION
This PR introduces retries because salt alternatives.install sometimes fails on 1st run.
The SuSE workarounds are now removed.

Verified on SuSE