### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/golang/defaults.yaml
+++ b/golang/defaults.yaml
@@ -7,21 +7,22 @@ golang:
   go_path: /usr/local/golang/packages
   pkg:
     name: go
-    use_upstream_repo: False
-    use_upstream_archive: True
+    use_upstream_repo: false
+    use_upstream_archive: true
     archive:
       name: /usr/local
       uri: https://storage.googleapis.com/golang
       source: None
       source_hash: None
-      trim_output: True   {# works in 2018.3.2. onwards #}
+      trim_output: true  # works in 2018.3.2. onwards
       archive_suffix: tar.gz
       archive_format: tar
-      enforce_toplevel: True
+      enforce_toplevel: true
     repo: {}
 
   rootgroup: root
-  kernel: {{ grains.kernel | lower }}
+  # Provided in `map.jinja` via. `grains.kernel`
+  kernel: ''
   config: '/etc/golang'
   environ_file: /etc/default/golang.sh
   environ: []
@@ -32,5 +33,5 @@ golang:
   winner: defaults
 
   linux:
-    #'Alternatives system' priority: zero disables (default)
+    # 'Alternatives system' priority: zero disables (default)
     altpriority: 0

--- a/golang/map.jinja
+++ b/golang/map.jinja
@@ -47,6 +47,12 @@
 %}
 {%- set golang = config %}
 
+{#- Post-processing for specific non-YAML customisations #}
+{%- do golang.update({'kernel': grains.kernel | lower}) %}
+{%- if grains.os == 'MacOS' %}
+{%-   set macos_group = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
+{%-   do golang.update({'rootgroup': macos_group}) %}
+{%- endif %}
 
 {#- archive jinja #}
 {%- if golang.pkg.use_upstream_archive %}

--- a/golang/osfamilymap.yaml
+++ b/golang/osfamilymap.yaml
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                                                             
+# -*- coding: utf-8 -*-
 # vim: ft=yaml
 #
 # Setup variables using grains['os_family'] based logic.
@@ -10,10 +10,6 @@
 # you will need to provide at least an empty dict in this file, e.g.
 # osfamilymap: {}
 ---
-{%- if grains.os == 'MacOS' %}
-{%-   set macos_rootgroup = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
-{%- endif %}
-
 Debian: {}
 
 RedHat: {}
@@ -49,8 +45,6 @@ Windows:
       source: https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz
 
 MacOS:
-  rootgroup: {{ macos_rootgroup | d('') }}
   pkg:
     archive:
       source: https://storage.googleapis.com/golang/go1.10.2.darwin-amd64.tar.gz
-

--- a/pillar.example
+++ b/pillar.example
@@ -13,7 +13,7 @@ golang:
       uri: https://storage.googleapis.com/golang
 
   linux:
-    #'Alternatives system' priority: zero disables (default)
+    # 'Alternatives system' priority: zero disables (default)
     altpriority: 1000
 
   tofs:

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: golang formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
golang-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./golang/defaults.yaml
  10:24     warning  truthy value should be one of [false, true]  (truthy)
  11:27     warning  truthy value should be one of [false, true]  (truthy)
  17:57     warning  too few spaces before comment  (comments)
  17:58     warning  missing starting space in comment  (comments)
  20:25     warning  truthy value should be one of [false, true]  (truthy)
  24:13     error    too many spaces inside braces  (braces)
  24:35     error    too many spaces inside braces  (braces)
  35:6      warning  missing starting space in comment  (comments)

./golang/osfamilymap.yaml
  1:89      error    line too long (116 > 88 characters)  (line-length)
  1:24      error    trailing spaces  (trailing-spaces)
  56:1      error    too many blank lines (1 > 0)  (empty-lines)
  13:2      error    syntax error: found character '%' that cannot start any token

pillar.example
  16:6      warning  missing starting space in comment  (comments)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.