### PR TITLE
feat(go.cmd): basic go command support

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -72,6 +72,22 @@ via include list.
 This state will start the golang service and has a dependency on ``golang.config``
 via include list.
 
+``golang.cmd``
+^^^^^^^^^^^^^^
+
+This is a metastate for go command tasks.
+
+``golang.cmd.clean``
+^^^^^^^^^^^^^^^^^^^^
+
+This state runs ``go clean -i <item>...`` for each item in ``cmd.clean`` dict.
+
+``golang.cmd.goget``
+^^^^^^^^^^^^^^^^^^^^
+
+This state runs ``go get <item>...`` for each item in ``cmd.get`` dict.
+
+
 ``golang.clean``
 ^^^^^^^^^^^^^^^^
 

--- a/golang/clean.sls
+++ b/golang/clean.sls
@@ -2,5 +2,6 @@
 # vim: ft=sls
 
 include:
+  - .cmd.clean
   - .config.clean
   - .archive.clean

--- a/golang/cmd/clean.sls
+++ b/golang/cmd/clean.sls
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import golang with context %}
+ 
+    {%- for package in golang.cmd.clean %}
+
+golang-cmd-clean-cmd-run-go-clean-{{ package }}:
+  cmd.run:
+    - name: go clean -i {{ package }}...
+    - runas: {{ golang.rootuser }}
+
+    {%- endfor %}

--- a/golang/cmd/clean.sls
+++ b/golang/cmd/clean.sls
@@ -4,7 +4,7 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import golang with context %}
- 
+
     {%- for package in golang.cmd.clean %}
 
 golang-cmd-clean-cmd-run-go-clean-{{ package }}:

--- a/golang/cmd/goget.sls
+++ b/golang/cmd/goget.sls
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import golang with context %}
+
+    {%- for package in golang.cmd.goget %}
+
+golang-cmd-goget-cmd-run-go-get-{{ package }}:
+  cmd.run:
+    - name: go get {{ package }}
+    - runas: {{ golang.rootuser }}
+
+    {%- endfor %}

--- a/golang/cmd/goget.sls
+++ b/golang/cmd/goget.sls
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import golang with context %}

--- a/golang/cmd/init.sls
+++ b/golang/cmd/init.sls
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+include:
+  - .clean
+  - .goget

--- a/golang/defaults.yaml
+++ b/golang/defaults.yaml
@@ -5,6 +5,7 @@ golang:
   dir: /usr/local/go      ## go_root
   version: '1.10.1'
   go_path: /usr/local/golang/packages
+  rootuser: root
   pkg:
     name: go
     use_upstream_repo: false
@@ -35,3 +36,7 @@ golang:
   linux:
     # 'Alternatives system' priority: zero disables (default)
     altpriority: 0
+
+  cmd:
+    goget: []
+    clean: []

--- a/golang/init.sls
+++ b/golang/init.sls
@@ -8,3 +8,4 @@
 include:
   - {{ '.archive' if golang.pkg.use_upstream_archive else '.package' }}
   - .config
+  - .cmd

--- a/pillar.example
+++ b/pillar.example
@@ -14,7 +14,15 @@ golang:
 
   linux:
     # 'Alternatives system' priority: zero disables (default)
-    altpriority: 1000
+    altpriority: 9100
+
+  cmd:
+    goget:
+      - github.com/golang/example/hello
+      - github.com/golang/example/outyet
+    clean:
+      - github.com/golang/example/hello
+      - github.com/golang/example/outyet
 
   tofs:
     # The files_switch key serves as a selector for alternative


### PR DESCRIPTION
This PR introduces `golang.cmd` metastate with some basic **go command** support.